### PR TITLE
Implement deleteMessages

### DIFF
--- a/teloxide_tests/src/lib.rs
+++ b/teloxide_tests/src/lib.rs
@@ -58,6 +58,7 @@
 //!
 //! - /AnswerCallbackQuery
 //! - /DeleteMessage
+//! - /DeleteMessages
 //! - /EditMessageText
 //! - /EditMessageReplyMarkup
 //! - /EditMessageCaption

--- a/teloxide_tests/src/server/mod.rs
+++ b/teloxide_tests/src/server/mod.rs
@@ -14,18 +14,18 @@ use actix_web::{
 pub use responses::*;
 use routes::{
     answer_callback_query::*, ban_chat_member::*, copy_message::*, delete_message::*,
-    download_file::download_file, edit_message_caption::*, edit_message_reply_markup::*,
-    edit_message_text::*, forward_message::*, get_file::*, get_me::*, get_updates::*,
-    get_webhook_info::*, pin_chat_message::*, restrict_chat_member::*, send_animation::*,
-    send_audio::*, send_chat_action::*, send_contact::*, send_dice::*, send_document::*,
-    send_invoice::*, send_location::*, send_media_group::*, send_message::*, send_photo::*,
-    send_poll::*, send_sticker::*, send_venue::*, send_video::*, send_video_note::*, send_voice::*,
-    set_message_reaction::*, set_my_commands::*, unban_chat_member::*, unpin_all_chat_messages::*,
-    unpin_chat_message::*,
+    delete_messages::*, download_file::download_file, edit_message_caption::*,
+    edit_message_reply_markup::*, edit_message_text::*, forward_message::*, get_file::*, get_me::*,
+    get_updates::*, get_webhook_info::*, pin_chat_message::*, restrict_chat_member::*,
+    send_animation::*, send_audio::*, send_chat_action::*, send_contact::*, send_dice::*,
+    send_document::*, send_invoice::*, send_location::*, send_media_group::*, send_message::*,
+    send_photo::*, send_poll::*, send_sticker::*, send_venue::*, send_video::*, send_video_note::*,
+    send_voice::*, set_message_reaction::*, set_my_commands::*, unban_chat_member::*,
+    unpin_all_chat_messages::*, unpin_chat_message::*,
 };
 pub use routes::{
     copy_message::CopyMessageBody, delete_message::DeleteMessageBody,
-    edit_message_caption::EditMessageCaptionBody,
+    delete_messages::DeleteMessagesBody, edit_message_caption::EditMessageCaptionBody,
     edit_message_reply_markup::EditMessageReplyMarkupBody, edit_message_text::EditMessageTextBody,
     forward_message::ForwardMessageBody, send_animation::SendMessageAnimationBody,
     send_audio::SendMessageAudioBody, send_contact::SendMessageContactBody,
@@ -154,6 +154,7 @@ fn set_bot_routes(cfg: &mut ServiceConfig) {
             post().to(edit_message_reply_markup),
         )
         .route("/DeleteMessage", post().to(delete_message))
+        .route("/DeleteMessages", post().to(delete_messages))
         .route("/ForwardMessage", post().to(forward_message))
         .route("/CopyMessage", post().to(copy_message))
         .route("/AnswerCallbackQuery", post().to(answer_callback_query))

--- a/teloxide_tests/src/server/routes/delete_messages.rs
+++ b/teloxide_tests/src/server/routes/delete_messages.rs
@@ -1,0 +1,46 @@
+use std::sync::Mutex;
+
+use actix_web::{web, Responder};
+use serde::Deserialize;
+
+use super::BodyChatId;
+use crate::{
+    server::{
+        routes::{delete_message::DeleteMessageBody, make_telegram_result},
+        DeletedMessage,
+    },
+    state::State,
+};
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct DeleteMessagesBody {
+    pub chat_id: BodyChatId,
+    pub message_ids: Vec<i32>,
+}
+
+pub async fn delete_messages(
+    state: web::Data<Mutex<State>>,
+    body: web::Json<DeleteMessagesBody>,
+) -> impl Responder {
+    let mut lock = state.lock().unwrap();
+    let bot_request = body.into_inner();
+    // deleteMessages skips messages that are not found, no error is returned.
+    let mut deleted_messages = lock
+        .messages
+        .delete_messages(&bot_request.message_ids)
+        .into_iter()
+        .map(|m| DeletedMessage {
+            message: m.clone(),
+            bot_request: DeleteMessageBody {
+                chat_id: bot_request.chat_id.clone(),
+                message_id: m.id.0,
+            },
+        })
+        .collect();
+
+    lock.responses
+        .deleted_messages
+        .append(&mut deleted_messages);
+
+    make_telegram_result(true)
+}

--- a/teloxide_tests/src/server/routes/mod.rs
+++ b/teloxide_tests/src/server/routes/mod.rs
@@ -13,6 +13,7 @@ pub mod answer_callback_query;
 pub mod ban_chat_member;
 pub mod copy_message;
 pub mod delete_message;
+pub mod delete_messages;
 pub mod download_file;
 pub mod edit_message_caption;
 pub mod edit_message_reply_markup;
@@ -237,7 +238,9 @@ pub async fn get_raw_multipart_fields(
             Attachment {
                 raw_name: data.0.to_string(),
                 file_name: filename.to_string(),
-                file_data: from_utf8(&data.1).unwrap_or("error_getting_data").to_string(),
+                file_data: from_utf8(&data.1)
+                    .unwrap_or("error_getting_data")
+                    .to_string(),
             },
         );
     }

--- a/teloxide_tests/src/tests.rs
+++ b/teloxide_tests/src/tests.rs
@@ -186,6 +186,8 @@ pub enum AllCommands {
     #[command()]
     Delete,
     #[command()]
+    DeleteBatch,
+    #[command()]
     EditReplyMarkup,
     #[command()]
     Photo,
@@ -263,6 +265,10 @@ async fn handler(
         }
         AllCommands::Delete => {
             bot.delete_message(msg.chat.id, sent_message.id).await?;
+        }
+        AllCommands::DeleteBatch => {
+            bot.delete_messages(msg.chat.id, vec![sent_message.id, MessageId(404)])
+                .await?;
         }
         AllCommands::EditReplyMarkup => {
             bot.edit_message_reply_markup(msg.chat.id, sent_message.id)
@@ -1021,6 +1027,19 @@ async fn test_delete_message() {
     let last_deleted_response = bot.get_responses().deleted_messages.pop().unwrap();
 
     assert_eq!(last_sent_message.text(), Some("/delete"));
+    assert_eq!(last_deleted_response.message.id, last_sent_message.id);
+}
+
+#[tokio::test]
+async fn test_delete_messages() {
+    let mut bot = MockBot::new(MockMessageText::new().text("/deletebatch"), get_schema());
+
+    bot.dispatch().await;
+
+    let last_sent_message = bot.get_responses().sent_messages.pop().unwrap();
+    let last_deleted_response = bot.get_responses().deleted_messages.pop().unwrap();
+
+    assert_eq!(last_sent_message.text(), Some("/deletebatch"));
     assert_eq!(last_deleted_response.message.id, last_sent_message.id);
 }
 


### PR DESCRIPTION
It's the batch version of `deleteMessage` that does not return errors for messages that were not found.

Docs: https://core.telegram.org/bots/api#deletemessages

<!--
Before making this PR, please ensure the following:

- Documentation and tests are updated (if necessary)
- A new endpoint is added to teloxide_tests/src/lib.rs (if necessary)
-->
