### PR TITLE
Add support for UpdateKind::EditedMessage

### DIFF
--- a/teloxide_tests/src/mock_bot.rs
+++ b/teloxide_tests/src/mock_bot.rs
@@ -237,6 +237,10 @@ where
                     self.state.lock().unwrap().add_message(&mut message);
                     update.kind = UpdateKind::Message(message.clone());
                 }
+                UpdateKind::EditedMessage(mut message) => {
+                    self.state.lock().unwrap().edit_message(&mut message);
+                    update.kind = UpdateKind::EditedMessage(message.clone());
+                }
                 UpdateKind::CallbackQuery(mut callback) => {
                     if let Some(MaybeInaccessibleMessage::Regular(ref mut message)) =
                         callback.message

--- a/teloxide_tests/src/server/routes/edit_message_caption.rs
+++ b/teloxide_tests/src/server/routes/edit_message_caption.rs
@@ -35,8 +35,8 @@ pub async fn edit_message_caption(
             let mut lock = state.lock().unwrap();
             check_if_message_exists!(lock, message_id);
             lock.messages
-                .edit_message(message_id, "caption", body.caption.clone());
-            lock.messages.edit_message(
+                .edit_message_field(message_id, "caption", body.caption.clone());
+            lock.messages.edit_message_field(
                 message_id,
                 "caption_entities",
                 body.caption_entities.clone().unwrap_or_default(),

--- a/teloxide_tests/src/server/routes/edit_message_reply_markup.rs
+++ b/teloxide_tests/src/server/routes/edit_message_reply_markup.rs
@@ -37,11 +37,11 @@ pub async fn edit_message_reply_markup(
             let message = match body.reply_markup.clone() {
                 Some(reply_markup) => lock
                     .messages
-                    .edit_message(message_id, "reply_markup", reply_markup)
+                    .edit_message_field(message_id, "reply_markup", reply_markup)
                     .unwrap(),
                 None => lock
                     .messages
-                    .edit_message(message_id, "reply_markup", None::<()>)
+                    .edit_message_field(message_id, "reply_markup", None::<()>)
                     .unwrap(),
             };
 

--- a/teloxide_tests/src/server/routes/edit_message_text.rs
+++ b/teloxide_tests/src/server/routes/edit_message_text.rs
@@ -36,8 +36,8 @@ pub async fn edit_message_text(
             check_if_message_exists!(lock, message_id);
 
             lock.messages
-                .edit_message(message_id, "text", body.text.clone());
-            lock.messages.edit_message(
+                .edit_message_field(message_id, "text", body.text.clone());
+            lock.messages.edit_message_field(
                 message_id,
                 "entities",
                 body.entities.clone().unwrap_or(vec![]),

--- a/teloxide_tests/src/state.rs
+++ b/teloxide_tests/src/state.rs
@@ -50,4 +50,32 @@ impl State {
         log::debug!("Inserted message with {}.", message.id);
         self.messages.add_message(message.clone());
     }
+
+    pub(crate) fn edit_message(&mut self, message: &mut Message) {
+        let old_message = self.messages.get_message(message.id.0);
+
+        if old_message.is_none() {
+            log::error!(
+                "Not editing message with id {}, this id does not exist in the database.",
+                message.id
+            );
+            return;
+        }
+
+        if let Some(file_meta) = find_file(serde_json::to_value(&message).unwrap()) {
+            if self
+                .files
+                .iter()
+                .all(|f| f.meta.unique_id != file_meta.unique_id)
+            {
+                let file = File {
+                    meta: file_meta,
+                    path: "some_path.txt".to_string(), // This doesn't really matter
+                };
+                self.files.push(file);
+            }
+        }
+        log::debug!("Edited message with {}.", message.id);
+        self.messages.edit_message(message.clone());
+    }
 }


### PR DESCRIPTION
* A wrapper is introduced that changes a `Message`'s `into_update()` behavior. Having `edit_date` set seems to be a requirement for correct parsing.
* `MockBot` is updated to support `UpdateKind::EditedMessage`.
* Renamed the old `Messages::edit_message` to `edit_message_field` for clarity.
* I also fixed a couple of copy-paste errors along the way.

<!--
Before making this PR, please ensure the following:

- Documentation and tests are updated (if necessary)
- A new endpoint is added to teloxide_tests/src/lib.rs (if necessary)
-->
