### PR TITLE
Fix forward origin

### DIFF
--- a/teloxide_tests/src/tests.rs
+++ b/teloxide_tests/src/tests.rs
@@ -1084,6 +1084,10 @@ async fn test_forward_message() {
         last_sent_message.forward_date(),
         Some(first_sent_message.date)
     );
+    assert_eq!(
+        last_sent_message.forward_from_user().unwrap().id,
+        first_sent_message.from.as_ref().unwrap().id
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
According to the Telegram Bot API docs, the cases of the forward origins are as follows:

* `MessageOriginChannel`: The message was originally sent to a channel chat.
* `MessageOriginChat`: The message was originally sent on behalf of a chat to a group chat.
* `MessageOriginUser`: The message was originally sent by a known user.
* `MessageOriginHiddenUser`: The message was originally sent by an unknown user.

Testing with the actual bot API, I do get users, not the chat, for messages forwarded from a supergroup.

`MessageOriginHiddenUser` is determined by the user's settings, which are not exposed to the bot API.

<!--
Before making this PR, please ensure the following:

- Documentation and tests are updated (if necessary)
- A new endpoint is added to teloxide_tests/src/lib.rs (if necessary)
-->
